### PR TITLE
Allow the repository URL to be overridden to use a mirror server instead

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,3 +13,5 @@ elasticsearch_heap_size_min: 1g
 elasticsearch_heap_size_max: 2g
 
 elasticsearch_extra_options: ''
+
+elasticsearch_repository_url: ''

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -16,3 +16,11 @@
     repo: 'deb https://artifacts.elastic.co/packages/{{ elasticsearch_version }}/apt stable main'
     state: present
     update_cache: true
+  when: elasticsearch_repository_url == ''
+
+- name: Add Elasticsearch repository.
+  apt_repository:
+    repo: "deb {{ elasticsearch_repository_url }} stable main"
+    state: present
+    update_cache: true
+  when: elasticsearch_repository_url != ''


### PR DESCRIPTION
Allow the repository URL to be overridden to use a mirror server instead